### PR TITLE
Proof of concept of using CURL for fluent-bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,10 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 endif()
 
+SET(GCC_LIBCURL_LINK_FLAGS    "-L/usr/lib/x86_64-linux-gnu -lcurl")
+SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
+
+
 include(GNUInstallDirs)
 include(ExternalProject)
 include(cmake/FindJournald.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,9 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__FILENAME__=__FILE__")
 endif()
 
-SET(GCC_LIBCURL_LINK_FLAGS    "-L/usr/lib/x86_64-linux-gnu -lcurl")
-SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${GCC_COVERAGE_LINK_FLAGS}")
+set(CURL_LIBRARY "-lcurl") 
+find_package(CURL REQUIRED)
+include_directories(${CURL_INCLUDE_DIR})
 
 
 include(GNUInstallDirs)

--- a/plugins/out_stackdriver/CMakeLists.txt
+++ b/plugins/out_stackdriver/CMakeLists.txt
@@ -9,4 +9,4 @@ set(src
   stackdriver_helper.c
   )
 
-FLB_PLUGIN(out_stackdriver "${src}" "")
+FLB_PLUGIN(out_stackdriver "${src}" "curl")

--- a/plugins/out_stackdriver/stackdriver.c
+++ b/plugins/out_stackdriver/stackdriver.c
@@ -1846,12 +1846,18 @@ static void cb_stackdriver_flush(const void *data, size_t bytes,
         FLB_OUTPUT_RETURN(FLB_ERROR);
     }
     curl_easy_setopt(curl, CURLOPT_URL, FLB_STD_WRITE_URL);
-    curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER, token);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "Fluent-Bit");
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
  
     struct curl_slist *hs=NULL;
+    int len;
+    char header[512];
+
+    len = snprintf(header, sizeof(header) - 1,
+                   "Authorization: Bearer %s", token);
+    header[len] = '\0';
     hs = curl_slist_append(hs, "Content-Type: application/json");
+    hs = curl_slist_append(hs, header);
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, hs);
     
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, payload_size);


### PR DESCRIPTION
This is a proof of concept of using CURL instead of mbed_tls for encryption with fluent-bit. CURL is configured to use open_ssl. This results in a performance improvement, however this doesn't implement multi-threading or async IO logic